### PR TITLE
Refactor packaging Structure

### DIFF
--- a/FaderSyncPlugin/FaderSyncPlugin.csproj
+++ b/FaderSyncPlugin/FaderSyncPlugin.csproj
@@ -37,24 +37,24 @@
     <!-- Pre-Package the plugin -->
     <Target Name="Package" AfterTargets="Publish">
         <PropertyGroup>
-            <PackageDir Condition="'$(PackageDir)' == ''">$([System.IO.Path]::Combine($(PublishDir),'..','package'))/</PackageDir>
-            <PackagePath Condition="'$(PackagePath)' == ''">$([System.IO.Path]::Combine($(PackageDir),'$(AssemblyName)-$(RuntimeIdentifier).zip'))</PackagePath>
+            <PackageDir>$([System.IO.Path]::Combine($(PublishDir),'..','package'))/</PackageDir>
+            <PackagePath>$([System.IO.Path]::Combine($(PackageDir),'$(AssemblyName)-$(RuntimeIdentifier).zip'))</PackagePath>
         </PropertyGroup>
         
         <MakeDir Directories="$(PackageDir)"/>
         
         <!-- OBS expects a specific directory structure for their plugins -->
-        <MakeDir Directories="$(PackageDir)package-src\bin\64bit" />
-        <MakeDir Directories="$(PackageDir)package-src\data" />
+        <MakeDir Directories="$(PackageDir)package-src\$(AssemblyName)\bin\64bit" />
+        <MakeDir Directories="$(PackageDir)package-src\$(AssemblyName)\data" />
 
         <!-- Include LICENSE file package -->
-        <Copy SourceFiles="$(SolutionDir)LICENSE" DestinationFolder="$(PackageDir)package-src\"/>
+        <Copy SourceFiles="$(SolutionDir)LICENSE" DestinationFolder="$(PackageDir)package-src\$(AssemblyName)\"/>
         
         <!-- Copy plugin files and package plugin -->
         <ItemGroup>
             <PublishedFiles Include="$(MSBuildProjectDirectory)\$(PublishDir)\**" />
         </ItemGroup>
-        <Copy SourceFiles="@(PublishedFiles)" DestinationFolder="$(PackageDir)\package-src\bin\64bit"/>
+        <Copy SourceFiles="@(PublishedFiles)" DestinationFolder="$(PackageDir)\package-src\$(AssemblyName)\bin\64bit"/>
         <ZipDirectory DestinationFile="$(PackagePath)" SourceDirectory="$(PackageDir)\package-src\" Overwrite="true"/>
     </Target>
 


### PR DESCRIPTION
Added a new sub directory to the package archive with the same name as the .dll/.so file, because OBS will only load the plugin file if it has the same name as the directory.